### PR TITLE
Add button styling for Video.js 6

### DIFF
--- a/dist/videojs.airplay.css
+++ b/dist/videojs.airplay.css
@@ -2,4 +2,6 @@
 
 .vjs-airplay-control { font-family: 'videojs-airplayButton'; float: right; cursor: pointer; }
 
-.vjs-airplay-control:before { content: "\e900"; }
+.vjs-airplay-control:before, .vjs-v6 .vjs-airplay-control .vjs-icon-placeholder::before { content: "\e900"; }
+
+.vjs-v6 .vjs-airplay-control:before { content: none; }

--- a/src/videojs-airplay.scss
+++ b/src/videojs-airplay.scss
@@ -17,6 +17,11 @@ $icon-font-path: 'fonts' !default;
   cursor: pointer;
 }
 
-.vjs-airplay-control:before {
+.vjs-airplay-control:before,
+.vjs-v6 .vjs-airplay-control .vjs-icon-placeholder::before {
   content: "\e900";
+}
+
+.vjs-v6 .vjs-airplay-control:before {
+  content: none;
 }


### PR DESCRIPTION
In Video.js 6 the font icon is placed on a `.vjs-icon-placeholder` element within the button. Using the v5 styling isn't entirely broken but the icon is too small.

Updated with styles for v6, maintaining compatibility with v5.